### PR TITLE
Macro improvements

### DIFF
--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -17,9 +17,12 @@
 	#define CI_PROFILE_CPU( name, ... )		perf::ScopedCpuProfiler __ci_cpu_profile{ name, ##__VA_ARGS__ }
 	//! Constructs a ScopedGpuProfiler with identifier \a name. Uses the global GpuProfiler instance by default, you can optionally pass in a separate instance as the second parameter.
 	#define CI_PROFILE_GPU( name, ... )		perf::ScopedGpuProfiler __ci_gpu_profile{ name, ##__VA_ARGS__ }
+	//! Constructs both a ScopedCpuProfiler and ScopedGpuProfiler, using the global profiler instances.
+	#define CI_PROFILE( name )				CI_PROFILE_CPU( name ); CI_PROFILE_GPU( name )
 #else
 	#define CI_PROFILE_CPU( name )
 	#define CI_PROFILE_GPU( name )
+	#define CI_PROFILE( name )
 #endif
 
 #if defined( CINDER_DLL )

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -15,12 +15,14 @@
 #if CI_PROFILING
 #define CI_PROFILE_CPU( name )	CI_SCOPED_CPU( perf::detail::globalCpuProfiler(), name ) 
 #define CI_PROFILE_GPU( name )	CI_SCOPED_GPU( perf::detail::globalGpuProfiler(), name ) 
+#define CI_PROFILE( name )		do { CI_PROFILE_CPU( name ); CI_PROFILE_GPU( name ); } while( 0 )
 
 #define CI_SCOPED_CPU( profiler, name ) perf::ScopedCpuProfiler __ci_cpu_profile{ profiler, name }
 #define CI_SCOPED_GPU( profiler, name ) perf::ScopedGpuProfiler __ci_gpu_profile{ profiler, name }
 #else
 #define CI_PROFILE_CPU( name )
 #define CI_PROFILE_GPU( name )
+#define CI_PROFILE( name )
 
 #define CI_SCOPED_CPU( profiler, name )
 #define CI_SCOPED_GPU( profiler, name )


### PR DESCRIPTION
1) Combined `	Combined CI_PROFILE_CPU/GPU` and `CI_SCOPED_CPU/GPU` by using a variatic macro argument and optional arg in the scoped class.

2) Added `CI_PROFILE()`, which combines both `CI_PROFILE_CPU` and `CI_PROFILE_GPU` where you only need to provide one name, and it uses the global profilers.