### PR TITLE
updated the export macro to match cinder scheme

### DIFF
--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -25,12 +25,10 @@
 	#define CI_PROFILE( name )
 #endif
 
-#if defined( CINDER_DLL )
-	#if defined( PERF_EXPORT )
-		#define PERF_API __declspec(dllexport)
-	#else
-		#define PERF_API __declspec(dllimport)
-	#endif
+#if defined( PERF_SHARED_BUILD )
+	#define PERF_API __declspec(dllexport)
+#elif defined( PERF_SHARED )
+	#define PERF_API __declspec(dllimport)
 #else
 	#define PERF_API
 #endif


### PR DESCRIPTION
This updates the macro naming conventions to match what we resolved at when completing the cinder DLL stuff in https://github.com/cinder/Cinder/pull/1770.