### PR TITLE
Added clear() methods to CpuProfiler and GpuProfiler

### DIFF
--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -118,6 +118,11 @@ void CpuProfiler::stop( const std::string& timerName )
 	mTimers.at( timerName ).stop();
 }
 
+void CpuProfiler::clear()
+{
+	mTimers.clear();
+}
+
 std::unordered_map<std::string, double> CpuProfiler::getElapsedTimes()
 {
 	std::unordered_map<std::string, double> elapsedTimes;
@@ -154,6 +159,11 @@ void GpuProfiler::stop( const std::string& timerName )
 #if ! defined( CINDER_MSW )
 	sActiveTimer = false;
 #endif
+}
+
+void GpuProfiler::clear()
+{
+	mTimers.clear();
 }
 
 std::unordered_map<std::string, double> GpuProfiler::getElapsedTimes()

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -101,6 +101,7 @@ namespace perf {
 	public:
 		void start( const std::string& timerName );
 		void stop( const std::string& timerName );
+		void clear();
 
 		std::unordered_map<std::string, double> getElapsedTimes();
 	private:
@@ -111,6 +112,7 @@ namespace perf {
 	public:
 		void start( const std::string& timerName );
 		void stop( const std::string& timerName );
+		void clear();
 
 		std::unordered_map<std::string, double> getElapsedTimes();
 	private:


### PR DESCRIPTION
Finally addressing https://github.com/num3ric/Cinder-Profiler/issues/8, which allows you to clear out some residual times in your profiler gui after you've turned some things off in the app.